### PR TITLE
Remove the need for nested folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-_work
+scikit-learn
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -10,23 +10,10 @@ You must have
 
 ## Get Started
 
-* Open the repository within VS Code, click on the remote development button on bottom left.
-
-* Choose `Reopen in Container`
-
-* Open the built-in terminal within VS Code.
-
-* Edit `setup.sh` to point to your own fork of `scikit-learn`.
-
-* Run the following command to setup everything.
-
-```
-./setup.sh
-```
-
-> This command can take a really really long time.
-
-* You are good to go! `scikit-learn` is built and installed within `_work/scikit-learn` directory.
+1. Clone this repo
+2. `./setup.sh <your fork>`, ie `./setup.sh yifeiyin`
+3. Open VSCode with the folder `./scikit` if it's not open already – the script will open vscode for you if the command `code` is available
+4. Run `./.devcontainer/setup.sh` **inside the container**
 
 ## Contributing
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$1" ]; then
     echo 'Usage: ./setup.sh <fork>'
@@ -24,10 +24,18 @@ EOF
 
 chmod +x ./.devcontainer/setup.sh
 
-echo 'Now, open scikit-learn in vscode remote container.'
-echo 'Then, run `./.devcontainer/setup.sh` in the terminal.'
-
+echo '-------------------------------'
+echo
 if which code > /dev/null; then
     echo 'Opening vscode for you...'
     code .
+else
+    echo 'Now, open scikit-learn in VSCode.'
 fi
+echo
+echo 'Choose "Reopen in Container" in the popup.'
+echo
+echo 'Then, run `./.devcontainer/setup.sh` in the container terminal.'
+echo
+echo '-------------------------------'
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,33 @@
 #!/bin/bash
 
-# Modify this variable to point to your own fork
-FORK=https://github.com/junzhengca/scikit-learn.git
+if [ -z "$1" ]; then
+    echo 'Usage: ./setup.sh <fork>'
+    exit 1
+fi
 
-mkdir _work
-cd _work
-git clone "$FORK"
+# Modify this variable to point to your own fork
+FORK="https://github.com/$1/scikit-learn.git"
+
+[ -d 'scikit-learn' ] || git clone "$FORK" scikit-learn
 cd scikit-learn
 git remote add upstream https://github.com/scikit-learn/scikit-learn.git
+
+echo 'Putting a hidden devcontainer folder in scikit repo...'
+cp -r ../.devcontainer ./
+echo '.devcontainer/' >> .git/info/exclude
+
+cat > ./.devcontainer/setup.sh <<EOF
+# Run this file **inside the container**
 pip install --no-build-isolation --editable .
 pre-commit install
+EOF
+
+chmod +x ./.devcontainer/setup.sh
+
+echo 'Now, open scikit-learn in vscode remote container.'
+echo 'Then, run `./.devcontainer/setup.sh` in the terminal.'
+
+if which code > /dev/null; then
+    echo 'Opening vscode for you...'
+    code .
+fi


### PR DESCRIPTION
- `git`-related commands are now ran outside the container
  - known issue: git might convert the line endings during clone in Windows; might need to do a one-off `git reset --hard`
- the outer folders can be thrown away after the setup
- and some other general updates to the script; see if you like it
